### PR TITLE
Use snprintf instead of sprintf

### DIFF
--- a/xposed.cpp
+++ b/xposed.cpp
@@ -134,7 +134,11 @@ bool addXposedToClasspath(bool zygote) {
             setenv("CLASSPATH", XPOSED_JAR, 1);
         } else {
             char classPath[4096];
-            snprintf(classPath, sizeof(classPath), "%s:%s", XPOSED_JAR, oldClassPath);
+            int newLength = snprintf(classPath, sizeof(classPath), "%s:%s", XPOSED_JAR, oldClassPath);
+            if (newLength >= sizeof(classPath)) {
+                ALOGE("ERROR: CLASSPATH would exceed 4096 characters");
+                return false;
+            }
             setenv("CLASSPATH", classPath, 1);
         }
         ALOGI("Added Xposed (%s) to CLASSPATH.\n", XPOSED_JAR);


### PR DESCRIPTION
Use `snprintf` instead of `sprintf` to avoid potential (security) issues when encountering a ridiculously long `CLASSPATH`.
