### PR TITLE
ferror() after fclose() bug

### DIFF
--- a/xposed_service.cpp
+++ b/xposed_service.cpp
@@ -765,7 +765,7 @@ status_t XposedService::readFile(const String16& filename16, int32_t offset, int
         status_t err = ferror(f);
         fclose(f);
         if (errormsg) *errormsg = formatToString16("%s during fseek() to offset %d for %s", strerror(err), offset, filename);
-        return ferror(f);
+        return err;
     }
 
     // Read the file


### PR DESCRIPTION
fixed either a wrong value being returned, or a segfault (depending on
how bionic handles its files)